### PR TITLE
refact: adds peer review comments to reebasefeederpool

### DIFF
--- a/contracts/feeders/FeederPool.sol
+++ b/contracts/feeders/FeederPool.sol
@@ -186,7 +186,7 @@ contract FeederPool is
      * @param _input                Address of the bAsset to deposit.
      * @param _inputQuantity        Quantity in input token units.
      * @param _minOutputQuantity    Minimum fpToken quantity to be minted. This protects against slippage.
-     * @param _recipient            Receipient of the newly minted fpTokens
+     * @param _recipient            Recipient of the newly minted fpTokens
      * @return mintOutput           Quantity of fpToken minted from the deposited bAsset.
      */
     function mint(
@@ -219,7 +219,7 @@ contract FeederPool is
      * @param _inputs               Address of the bAssets to deposit.
      * @param _inputQuantities      Quantity in input token units.
      * @param _minOutputQuantity    Minimum fpToken quantity to be minted. This protects against slippage.
-     * @param _recipient            Receipient of the newly minted fpTokens
+     * @param _recipient            Recipient of the newly minted fpTokens
      * @return mintOutput           Quantity of fpToken minted from the deposited bAssets.
      */
     function mintMulti(
@@ -727,7 +727,7 @@ contract FeederPool is
         uint64 endA = ampData_.targetA;
         uint64 endTime = ampData_.rampEndTime;
 
-        // If still changing, work out based on current timestmap
+        // If still changing, work out based on current timestamp
         if (block.timestamp < endTime) {
             uint64 startA = ampData_.initialA;
             uint64 startTime = ampData_.rampStartTime;
@@ -819,7 +819,7 @@ contract FeederPool is
     }
 
     /**
-     * @dev Set the ecosystem fee for sewapping bAssets or redeeming specific bAssets
+     * @dev Set the ecosystem fee for swapping bAssets or redeeming specific bAssets
      * @param _swapFee       Fee calculated in (%/100 * 1e18)
      * @param _redemptionFee Fee calculated in (%/100 * 1e18)
      * @param _govFee        Fee calculated in (%/100 * 1e18)

--- a/tasks/deployFeeders.ts
+++ b/tasks/deployFeeders.ts
@@ -11,7 +11,8 @@ import {
     AlchemixIntegration,
     AlchemixIntegration__factory,
     FeederWrapper__factory,
-} from "types/generated"
+    FeederPoolTypes,
+} from "types"
 import { simpleToExactAmount } from "@utils/math"
 import { ALCX, alUSD, BUSD, CREAM, cyMUSD, GUSD, mUSD, tokens } from "./utils/tokens"
 import { deployContract, logTxDetails } from "./utils/deploy-utils"
@@ -26,7 +27,9 @@ task("deployFeederPool", "Deploy Feeder Pool")
     .addOptionalParam("min", "Minimum asset weight of the basket as a percentage. eg 10 for 10% of the basket.", 10, types.int)
     .addOptionalParam("max", "Maximum asset weight of the basket as a percentage. eg 90 for 90% of the basket.", 90, types.int)
     .addOptionalParam("speed", "Defender Relayer speed param: 'safeLow' | 'average' | 'fast' | 'fastest'", "fast", types.string)
+    .addOptionalParam("type", "Type of feeder pool 'FeederPool' | 'RebasedFeederPool'", "FeederPool", types.string)
     .setAction(async (taskArgs, hre) => {
+        // TODO  -  usd+ , no need to add a new one , this can be reused.
         const signer = await getSigner(hre, taskArgs.speed)
         const chain = getChain(hre)
 
@@ -52,7 +55,12 @@ task("deployFeederPool", "Deploy Feeder Pool")
         }
 
         // Deploy Feeder Pool
-        await deployFeederPool(signer, poolData, hre)
+        await deployFeederPool(
+            signer,
+            poolData,
+            hre,
+            taskArgs.max === "FeederPool" ? FeederPoolTypes.FeederPool : FeederPoolTypes.RebasedFeederPool,
+        )
     })
 
 task("deployNonPeggedFeederPool", "Deploy Non Pegged Feeder Pool")
@@ -91,7 +99,7 @@ task("deployNonPeggedFeederPool", "Deploy Non Pegged Feeder Pool")
         }
 
         // Deploy Feeder Pool
-        await deployFeederPool(signer, poolData, hre)
+        await deployFeederPool(signer, poolData, hre, FeederPoolTypes.NonPeggedFeederPool)
     })
 
 task("deployAlcxInt", "Deploy Alchemix integration contract for alUSD Feeder Pool")

--- a/tasks/utils/tokens.ts
+++ b/tasks/utils/tokens.ts
@@ -508,6 +508,8 @@ export const RmBPT: Token = {
     quantityFormatter: "USD",
 }
 
+// TODO - add usd+  configuration here.
+
 export const tokens = [
     AAVE,
     stkAAVE,

--- a/test-fork/feeders/feeders-musd-overnight.spec.ts
+++ b/test-fork/feeders/feeders-musd-overnight.spec.ts
@@ -1,0 +1,74 @@
+import { impersonateAccount } from "@utils/fork"
+import { simpleToExactAmount } from "@utils/math"
+import { expect } from "chai"
+import { ethers, network } from "hardhat"
+import { PFRAX, PmUSD } from "tasks/utils"
+import { Account } from "types"
+import { ERC20, ERC20__factory, RebasedFeederPool, RebasedFeederPool__factory, IERC20, IERC20__factory } from "types/generated"
+
+const accountAddress = "0xdccb7a6567603af223c090be4b9c83eced210f18"
+
+// set the correct hardhat configuration file at "test:file:fork": "yarn hardhat --config hardhat-fork.config.ts test",
+// set env variable NODE_URL pointing to the correct node,
+// yarn test:file:fork   TEST_FILE.spec.ts
+
+// Integration tests with day to day actions for example :
+// Deployment of the fPool with close to real data.
+//  Alice deposits some tokens, bob  deposits some tokens, alice withdraw after some days and bob withdraw after some days.
+//  Alice mints some tokens, bob  redeems some tokens
+//  Permutations of multiple mints and redeems
+//  Stress the behavior of _getMemBassetData()#bAssetData[F_INDEX].vaultBalance is it prone to price manipulation ? For example, flash loan attacks
+//  Stress the behavior of _updateBassetData()#data.bAssetData[F_INDEX].vaultBalance is it prone to price manipulation ?
+//  Are those  2 scenarios cover by contracts/feeders/FeederLogic.sol#computeMint? require(_inBounds(x, sum, _config.limits), "Exceeds weight limits");
+// The price of the fpToken can be manipulated by sending fasset token directly to the pool, 
+// await fAsset.connect(sa.default.signer).approve(details.pool.address, simpleToExactAmount(XXXXX, 6))
+// await fAsset.connect(sa.default.signer).transfer(details.pool.address, simpleToExactAmount(XXXXX, 6)) // this will increase the price 
+// TWAP
+context.skip("Overnight Feeder Pool on Polygon", () => {
+    let account: Account
+
+    let musd: IERC20
+
+    before("reset block number", async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: process.env.NODE_URL,
+                        blockNumber: 16440763,
+                    },
+                },
+            ],
+        })
+        account = await impersonateAccount(accountAddress)
+
+        musd = await IERC20__factory.connect(PmUSD.address, account.signer)
+    })
+    it("Test connectivity", async () => {
+        const currentBlock = await ethers.provider.getBlockNumber()
+        console.log(`Current block ${currentBlock}`)
+        const startEther = await account.signer.getBalance()
+        console.log(`Deployer ${account} has ${startEther} Ether`)
+    })
+    it("Approve spend of usd+", async () => {
+        // TODO
+    })
+    it("Approve spend of mUSD", async () => {
+        // TODO
+    })
+    it("Mint usdFp", async () => {
+        // TODO
+    })
+    it("vaultBalance behavior when a whale deposits or flashloan attack, how does it behave?", async () => {
+        // function _getMemBassetData() internal view returns (BassetData[] memory bAssetData) {
+        //     bAssetData = new BassetData[](NUM_ASSETS);
+        //     bAssetData[M_INDEX] = data.bAssetData[M_INDEX];
+        //     bAssetData[F_INDEX].vaultBalance = uint128(IERC20(data.bAssetPersonal[F_INDEX].addr).balanceOf(address(this)));
+        //     bAssetData[F_INDEX].ratio = data.bAssetData[F_INDEX].ratio;
+        // }
+        // function _updateBassetData() internal {
+        //     data.bAssetData[F_INDEX].vaultBalance = uint128(IERC20(data.bAssetPersonal[F_INDEX].addr).balanceOf(address(this)));
+        // }
+    })
+})

--- a/test/feeders/mint.spec.ts
+++ b/test/feeders/mint.spec.ts
@@ -30,8 +30,14 @@ describe("Feeder - Mint", () => {
         use2dp = false,
         useRedemptionPrice = false,
     ): Promise<void> => {
-        details = await feederMachine.deployFeeder(feederWeights, mAssetWeights, useLendingMarkets,
-            useInterestValidator, use2dp, useRedemptionPrice)
+        details = await feederMachine.deployFeeder(
+            feederWeights,
+            mAssetWeights,
+            useLendingMarkets,
+            useInterestValidator,
+            use2dp,
+            useRedemptionPrice,
+        )
     }
 
     before("Init contract", async () => {
@@ -142,6 +148,8 @@ describe("Feeder - Mint", () => {
         sender: Account = sa.default,
         quantitiesAreExact = true,
     ): Promise<MintOutput> => {
+        const priceBefore = await fd.pool.getPrice()
+
         const pool = fd.pool.connect(sender.signer)
 
         // Get before balances
@@ -213,6 +221,9 @@ describe("Feeder - Mint", () => {
         // VaultBalance should update for this asset
         const assetAfter = await feederMachine.getAsset(details, inputAsset.address)
         expect(BN.from(assetAfter.vaultBalance), "vault balance after").eq(BN.from(assetBefore.vaultBalance).add(assetQuantityExact))
+        const priceAfter = await fd.pool.getPrice()
+
+        console.log("priceBefore", priceBefore.toString(), "priceAfter", priceAfter.toString())
 
         return {
             outputQuantity: outputQuantityExact,

--- a/types/machines.ts
+++ b/types/machines.ts
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-shadow */
 import { BN } from "../test-utils/math"
 import { EthAddress } from "./common"
 import { Basset } from "../test-utils/mstable-objects"
-import { MockERC20 } from "./generated"
+import { MockERC20, FeederPool, NonPeggedFeederPool, RebasedFeederPool } from "./generated"
 
 export interface ATokenDetails {
     bAsset: EthAddress
@@ -50,4 +51,12 @@ export interface ActionDetails {
     expectInteraction: boolean
     amount?: BN
     rawBalance?: BN
+}
+
+export type FeederPoolType = FeederPool | NonPeggedFeederPool | RebasedFeederPool
+
+export enum FeederPoolTypes {
+    FeederPool,
+    NonPeggedFeederPool,
+    RebasedFeederPool,
 }


### PR DESCRIPTION
I refactored some ts files adding the new type of FeederPool and added some comments that can be deleted after resolved. 

### Fork Test
- [ ] Please pay attention to this file test-fork/feeders/feeders-musd-overnight.spec.ts, it is a small example of integration test that are missing , there are other fork tests on the same  path that can be use as a guide. 

These kind of test are very important as a test against real scenarios and help to find other type of issues. 
 - For example , it helps to validate the arguments to deploy the feeder pool are correct and avoid issues at deployment phase. 
 - [ ] Add different permutations of real case scenarios with multiple users, alice, bob, etc. 


### Unit Test
 - [ ] Add unit test  to important branches that are still not covered. 
 <img width="949" alt="Screenshot 2022-05-09 at 16 35 05" src="https://user-images.githubusercontent.com/11393816/167446015-0427c4e6-62b9-4d46-80e1-ecc87c35e59b.png">

<img width="702" alt="Screenshot 2022-05-09 at 16 36 21" src="https://user-images.githubusercontent.com/11393816/167445993-d038ae9e-d39e-4097-b95c-4719ffd21726.png">

 - [ ] The price is never evaluated, this is quite important as it is affected by the fAsset.balanceOf(pool) 
 - [ ] 
<img width="641" alt="Screenshot 2022-05-09 at 16 36 43" src="https://user-images.githubusercontent.com/11393816/167445985-fac5a2b4-67b9-4a3c-9c70-6208cdec07e3.png">

### Feedback 
I am a little bit concern of a price manipulation vector,  as the it can be pumped by sending fAssets to the pool, 
Sending tokens directly to the pool,  do not mint new shares or change the total supply , it skip  validations , but still it impacts some core calculations, pumping the price. 

```
bAssetData[F_INDEX].vaultBalance = uint128(IERC20(data.bAssetPersonal[F_INDEX].addr).balanceOf(address(this)));
```

Could a malicious user deposit into the pool first, then pump the price,  redeem  more tokens that it should   and walk away or arb another pool ? 
It would be costly, yes, but could we get some numbers / test / that proof this is not a profitable tx. ? 








